### PR TITLE
OPS-4707 Ensure priority is auto-calculated

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ To overcome this limitation, all rules in this module are indexed by their corre
 This also means that whenever the expression changes, the rule will be recreated. Changes in all other values will not trigger a recreated.
 
 
+## Priority of rules
+
+This module omits the `priority` key for rulesets and auto-calculates those by the order they appear in the `rules` list.
+
+
 ## Example
 
 `terraform.tfvars`:
@@ -25,7 +30,6 @@ domain = "domain.tld"
 
 rules = [
   {
-    priority    = 1
     description = "Test (WAF Bypass)"
     paused      = false
     action      = "bypass"
@@ -33,7 +37,6 @@ rules = [
     products    = ["waf"]
   },
   {
-    priority    = 2
     description = "Test"
     paused      = false
     action      = "allow"
@@ -95,7 +98,6 @@ Type:
 
 ```hcl
 list(object({
-    priority    = number
     description = string
     paused      = bool
     action      = string

--- a/locals.tf
+++ b/locals.tf
@@ -8,7 +8,6 @@ locals {
   #
   # rules = [
   #   {
-  #     priority    = <priority>
   #     description = <description>
   #     paused      = <paused>
   #     action      = <action>
@@ -16,7 +15,6 @@ locals {
   #     products    = []
   #   },
   #   {
-  #     priority    = <priority>
   #     description = <description>
   #     paused      = <paused>
   #     action      = <action>
@@ -30,7 +28,7 @@ locals {
   #
   # rules = {
   #   <expression> = {
-  #     priority    = <priority>
+  #     priority    = <auto-calculated>
   #     description = <description>
   #     paused      = <paused>
   #     action      = <action>
@@ -38,7 +36,7 @@ locals {
   #     products    = []
   #   },
   #   <expression> = {
-  #     priority    = <priority>
+  #     priority    = <auto-calculated>
   #     description = <description>
   #     paused      = <paused>
   #     action      = <action>
@@ -46,5 +44,11 @@ locals {
   #     products    = []
   #   },
   # }
-  rules = { for i, v in var.rules : var.rules[i]["expression"] => v }
+  rules = { for idx, item in var.rules : var.rules[idx]["expression"] => merge(
+    item,
+    {
+      priority = idx + 1
+    }
+    )
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,6 @@ variable "domain" {
 variable "rules" {
   description = "List of Cloudflare firewall rule objects."
   type = list(object({
-    priority    = number
     description = string
     paused      = bool
     action      = string


### PR DESCRIPTION
# Ensure priority is auto-calculated

## Changes

This module now omits the `priority` key for rulesets and auto-calculates those by the order they appear in the `rules` list.

FYI: @danvaida 

## Tagging

As `terraform.tfvars` definition is incompatible with the current tagged version, the new git tag to be created will be a bump in the major version.