### PR TITLE
Release v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ rules = [
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | ~> 3.1.0 |
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | ~> 3.9.1 |
 
 <!-- TFDOCS_PROVIDER_END -->
 
@@ -65,7 +65,7 @@ rules = [
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 3.1.0 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 3.9.1 |
 
 <!-- TFDOCS_REQUIREMENTS_END -->
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 3.1.0"
+      version = "~> 3.9.1"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
# Release v1.0.1

Update Provider due to:

```
Error while installing cloudflare/cloudflare v3.1.0: could not query
│ provider registry for registry.terraform.io/cloudflare/cloudflare: failed
│ to retrieve cryptographic signature for provider: the request failed after
│ 2 attempts, please try again later: 503 Service Unavailable returned from
```

And also to be able to use Cloudflare's new FW action: `managed_challenge`